### PR TITLE
mentés képként

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -194,6 +194,10 @@ function szofajOnClick() {
 	update_incr = picture_delay * 2;
 }
 
+function saveOnClick() {
+	let fileFormat = this.elt.innerText;
+	saveCanvas("solaris", fileFormat);
+}
 
 
 function createButtonBox(strings, maxWidth, x = width / 2, y = height / 2, buttonWidth = 50, onclickfunction = letterOnClick) {
@@ -262,6 +266,9 @@ function setup() {
 
 	let szofajok = ["főnév","határozó","ige","melléknév"];
 	createButtonBox(szofajok, maxWidth*2, x = width / 2, y = 150,75, szofajOnClick);
+
+	let saveFormats  = ["png","jpg"];
+	createButtonBox(saveFormats, maxWidth*2, x = width / 2, y = 700, 75, saveOnClick);
 
 }
 

--- a/sketch.js
+++ b/sketch.js
@@ -115,7 +115,6 @@ class Word {
 		});
 		text(this.getText(), x , y+sizeX/2 +5);
 		console.log(this.getText(),x,y,y-sizeX/2 -5);
-		text("Írj valamit:)", width / 2 - 250, height / 15 + 10);
 	}
 
 	getText(){
@@ -196,7 +195,10 @@ function szofajOnClick() {
 
 function saveOnClick() {
 	let fileFormat = this.elt.innerText;
+	showText = false; //hide instructions before saving the canvas
+	draw(); //call draw without the text before saving
 	saveCanvas("solaris", fileFormat);
+	showText = true;
 }
 
 
@@ -243,7 +245,7 @@ function refreshImages(letterArray) {
 }
 
 let bigword
-
+let showText = true;
 
 
 function setup() {
@@ -275,6 +277,9 @@ function setup() {
 //TODO: use push and pop functionality better, wait for all pictures to load before drawing, because like this sometimes draws fail if we dont wait enough
 function draw() {
 	background(220);
+	if (showText) {
+		text("Írj valamit:)", width / 2 - 250, height / 15 + 10);
+	}
 	bigword.draw(500, 500, width / 2, height / 2);
 	
 


### PR DESCRIPTION
Két új gomb a meglévő createButtonBox functionnel, amikkel különböző formátumban le lehet menteni a képet.
Az egész canvast lementi, hogy az input szöveg is látszódjon. Szépséghiba, hogy így az: "Írj valamit :)" szöveg is benne van a képben, de ha azt kiszeded a canvasból, és mondjuk fölé rakod, akkor már jó.
Az issuek között volt az ötlet